### PR TITLE
Remove postgres healthcheck

### DIFF
--- a/.github/workflows/test.yml.jinja
+++ b/.github/workflows/test.yml.jinja
@@ -28,10 +28,6 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
-        # needed because the postgres container does not provide a healthcheck
-        options:
-          --health-cmd pg_isready --health-interval 10s --health-timeout 5s
-          --health-retries 5
     env:
       PIP_EXTRA_INDEX_URL: "https://wheelhouse.shopinvader.com/simple/"
     steps:


### PR DESCRIPTION
The oca-ci image [now waits for postgres](https://github.com/sbidoul/oca-ci/commit/8d2c0b5433b64d103503e2173fa81762327d7a37), which has
ample time to start during checkout and installation
of addons. So we save ~15s by letting it start in
parallel with installation.